### PR TITLE
feat(parser): add v1 Markdown diagnostics

### DIFF
--- a/internal/core/domain/diagnostic.go
+++ b/internal/core/domain/diagnostic.go
@@ -1,0 +1,22 @@
+package domain
+
+// ValidationRule identifies a v1 Markdown validation rule.
+type ValidationRule string
+
+const (
+	RuleEmptyHeading       ValidationRule = "empty-heading"
+	RuleDocumentTitle      ValidationRule = "document-title"
+	RuleHeadingHierarchy   ValidationRule = "heading-hierarchy"
+	RuleUnsupportedHeading ValidationRule = "unsupported-heading"
+	RuleMissingSteps       ValidationRule = "missing-steps"
+	RuleMissingCheckpoints ValidationRule = "missing-checkpoints"
+)
+
+// Diagnostic describes one v1 Markdown validation violation.
+type Diagnostic struct {
+	Source     string
+	Line       int
+	Rule       ValidationRule
+	Message    string
+	Suggestion string
+}

--- a/internal/core/parser/parser.go
+++ b/internal/core/parser/parser.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/9renpoto/casemd/internal/core/domain"
@@ -12,49 +13,229 @@ import (
 var (
 	orderedListRegex = regexp.MustCompile(`^\d+\.\s+(.*)`)
 	taskListRegex    = regexp.MustCompile(`^\*\s+\[[ x]\]\s+(.*)`)
+	headingRegex     = regexp.MustCompile(`^(#{1,6})(?:[ \t]+(.*))?$`)
 )
 
 // Parse extracts test cases from a Markdown reader.
 func Parse(r io.Reader) ([]domain.Case, error) {
-	scanner := bufio.NewScanner(r)
-	var cases []domain.Case
-	var currentCase *domain.Case
-	var majorItem, mediumItem string
+	cases, _, err := ParseWithDiagnostics("", r)
+	return cases, err
+}
 
+// Validate checks a Markdown reader against the v1 structure without returning cases.
+func Validate(source string, r io.Reader) ([]domain.Diagnostic, error) {
+	_, diagnostics, err := ParseWithDiagnostics(source, r)
+	return diagnostics, err
+}
+
+// ParseWithDiagnostics extracts test cases and reports all v1 structure violations.
+func ParseWithDiagnostics(source string, r io.Reader) ([]domain.Case, []domain.Diagnostic, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	var cases []domain.Case
+	var diagnostics []domain.Diagnostic
+	var currentCase *domain.Case
+	var currentCaseLine int
+	var majorItem, mediumItem string
+	var hasMajor, hasMedium bool
+	var majorLine, mediumLine int
+	var majorHasMedium, mediumHasCase bool
+	var sawHierarchy bool
+	var sawDocumentTitle bool
+
+	finishCurrentCase := func() {
+		if currentCase == nil {
+			return
+		}
+
+		if len(currentCase.ValidationSteps) == 0 {
+			diagnostics = append(diagnostics, domain.Diagnostic{
+				Source:     source,
+				Line:       currentCaseLine,
+				Rule:       domain.RuleMissingSteps,
+				Message:    "test case must contain at least one ordered step",
+				Suggestion: "add an ordered list item such as `1. Perform the action`",
+			})
+		}
+		if len(currentCase.Checkpoints) == 0 {
+			diagnostics = append(diagnostics, domain.Diagnostic{
+				Source:     source,
+				Line:       currentCaseLine,
+				Rule:       domain.RuleMissingCheckpoints,
+				Message:    "test case must contain at least one task-list checkpoint",
+				Suggestion: "add a task-list item such as `* [ ] Confirm the result`",
+			})
+		}
+
+		cases = append(cases, *currentCase)
+		currentCase = nil
+	}
+
+	finishMedium := func() {
+		if hasMedium && !mediumHasCase {
+			diagnostics = append(diagnostics, domain.Diagnostic{
+				Source:     source,
+				Line:       mediumLine,
+				Rule:       domain.RuleHeadingHierarchy,
+				Message:    "level 3 heading must contain at least one level 4 test case",
+				Suggestion: "add a `####` test case under this medium item",
+			})
+		}
+		hasMedium = false
+		mediumHasCase = false
+	}
+
+	finishMajor := func() {
+		finishMedium()
+		if hasMajor && !majorHasMedium {
+			diagnostics = append(diagnostics, domain.Diagnostic{
+				Source:     source,
+				Line:       majorLine,
+				Rule:       domain.RuleHeadingHierarchy,
+				Message:    "level 2 heading must contain at least one level 3 heading",
+				Suggestion: "add a `###` medium item under this major item",
+			})
+		}
+		hasMajor = false
+		majorHasMedium = false
+	}
+
+	lineNumber := 0
 	for scanner.Scan() {
+		lineNumber++
 		line := scanner.Text()
 		trimmedLine := strings.TrimSpace(line)
 
-		if strings.HasPrefix(line, "## ") {
-			majorItem = strings.TrimPrefix(line, "## ")
-			mediumItem = "" // Reset on new major item
-		} else if strings.HasPrefix(line, "### ") {
-			mediumItem = strings.TrimPrefix(line, "### ")
-		} else if strings.HasPrefix(line, "#### ") {
-			if currentCase != nil {
-				cases = append(cases, *currentCase)
+		if matches := headingRegex.FindStringSubmatch(line); len(matches) > 0 {
+			level := len(matches[1])
+			title := strings.TrimSpace(matches[2])
+
+			if title == "" {
+				diagnostics = append(diagnostics, domain.Diagnostic{
+					Source:     source,
+					Line:       lineNumber,
+					Rule:       domain.RuleEmptyHeading,
+					Message:    "heading must not be empty",
+					Suggestion: "add a descriptive title after the heading markers",
+				})
 			}
-			currentCase = &domain.Case{
-				MajorItem:  majorItem,
-				MediumItem: mediumItem,
-				MinorItem:  strings.TrimPrefix(line, "#### "),
+
+			switch level {
+			case 1:
+				if sawDocumentTitle || sawHierarchy {
+					diagnostics = append(diagnostics, domain.Diagnostic{
+						Source:     source,
+						Line:       lineNumber,
+						Rule:       domain.RuleDocumentTitle,
+						Message:    "document title must appear at most once and before the heading hierarchy",
+						Suggestion: "keep a single `#` document title before the first `##` major item",
+					})
+				}
+				sawDocumentTitle = true
+			case 2:
+				finishCurrentCase()
+				finishMajor()
+				majorItem = title
+				mediumItem = ""
+				hasMajor = true
+				majorLine = lineNumber
+				sawHierarchy = true
+			case 3:
+				finishCurrentCase()
+				finishMedium()
+				if !hasMajor {
+					diagnostics = append(diagnostics, domain.Diagnostic{
+						Source:     source,
+						Line:       lineNumber,
+						Rule:       domain.RuleHeadingHierarchy,
+						Message:    "level 3 heading requires a preceding level 2 heading",
+						Suggestion: "add a `##` major item before this heading",
+					})
+				}
+				mediumItem = title
+				hasMedium = true
+				mediumLine = lineNumber
+				mediumHasCase = false
+				if hasMajor {
+					majorHasMedium = true
+				}
+				sawHierarchy = true
+			case 4:
+				finishCurrentCase()
+				if !hasMajor || !hasMedium {
+					diagnostics = append(diagnostics, domain.Diagnostic{
+						Source:     source,
+						Line:       lineNumber,
+						Rule:       domain.RuleHeadingHierarchy,
+						Message:    "level 4 test case requires preceding level 2 and level 3 headings",
+						Suggestion: "add `##` and `###` parent headings before this test case",
+					})
+				}
+				if hasMedium {
+					mediumHasCase = true
+				}
+				currentCase = &domain.Case{
+					MajorItem:  majorItem,
+					MediumItem: mediumItem,
+					MinorItem:  title,
+				}
+				currentCaseLine = lineNumber
+				sawHierarchy = true
+			default:
+				diagnostics = append(diagnostics, domain.Diagnostic{
+					Source:     source,
+					Line:       lineNumber,
+					Rule:       domain.RuleUnsupportedHeading,
+					Message:    "v1 Markdown supports heading levels 1 through 4 only",
+					Suggestion: "use `####` for a test case or move this text into the test case body",
+				})
 			}
 		} else if matches := orderedListRegex.FindStringSubmatch(trimmedLine); len(matches) > 1 && currentCase != nil {
-			currentCase.ValidationSteps = append(currentCase.ValidationSteps, matches[1])
+			if step := strings.TrimSpace(matches[1]); step != "" {
+				currentCase.ValidationSteps = append(currentCase.ValidationSteps, step)
+			}
 		} else if matches := taskListRegex.FindStringSubmatch(trimmedLine); len(matches) > 1 && currentCase != nil {
-			// The regex captures the content, but the original spec wants the `* [ ]` part.
-			// Let's just use the trimmed line for checkpoints to preserve the marker.
-			currentCase.Checkpoints = append(currentCase.Checkpoints, trimmedLine)
+			if checkpoint := strings.TrimSpace(matches[1]); checkpoint != "" {
+				currentCase.Checkpoints = append(currentCase.Checkpoints, trimmedLine)
+			}
 		}
 	}
 
-	if currentCase != nil {
-		cases = append(cases, *currentCase)
+	finishCurrentCase()
+	finishMajor()
+	if !sawHierarchy {
+		diagnostics = append(diagnostics, domain.Diagnostic{
+			Source:     source,
+			Line:       1,
+			Rule:       domain.RuleHeadingHierarchy,
+			Message:    "document must contain a level 2, level 3, and level 4 heading hierarchy",
+			Suggestion: "add `##` and `###` parent headings followed by a `####` test case",
+		})
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return cases, nil
+	sortDiagnostics(diagnostics)
+	return cases, diagnostics, nil
+}
+
+func sortDiagnostics(diagnostics []domain.Diagnostic) {
+	ruleOrder := map[domain.ValidationRule]int{
+		domain.RuleEmptyHeading:       0,
+		domain.RuleDocumentTitle:      1,
+		domain.RuleHeadingHierarchy:   2,
+		domain.RuleUnsupportedHeading: 3,
+		domain.RuleMissingSteps:       4,
+		domain.RuleMissingCheckpoints: 5,
+	}
+
+	sort.SliceStable(diagnostics, func(i, j int) bool {
+		if diagnostics[i].Line != diagnostics[j].Line {
+			return diagnostics[i].Line < diagnostics[j].Line
+		}
+		return ruleOrder[diagnostics[i].Rule] < ruleOrder[diagnostics[j].Rule]
+	})
 }

--- a/internal/core/parser/parser_test.go
+++ b/internal/core/parser/parser_test.go
@@ -102,3 +102,168 @@ func TestParse(t *testing.T) {
 		t.Errorf("Parse() returned %+v, want %+v", actualCases, expectedCases)
 	}
 }
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		markdown  string
+		want      []domain.Diagnostic
+		wantCases int
+	}{
+		{
+			name: "valid document with optional title",
+			markdown: `# Inspection Sheet
+
+## Setup
+### Environment
+#### Dependencies
+1. Install required packages
+* [ ] Packages installed successfully
+`,
+			wantCases: 1,
+		},
+		{
+			name: "valid document without title",
+			markdown: `## Setup
+### Environment
+#### Dependencies
+1. Install required packages
+* [x] Packages installed successfully
+`,
+			wantCases: 1,
+		},
+		{
+			name: "headings without required parents",
+			markdown: `### Environment
+#### Dependencies
+1. Install required packages
+* [ ] Packages installed successfully
+`,
+			want: []domain.Diagnostic{
+				{Line: 1, Rule: domain.RuleHeadingHierarchy},
+				{Line: 2, Rule: domain.RuleHeadingHierarchy},
+			},
+			wantCases: 1,
+		},
+		{
+			name: "empty headings and incomplete case",
+			markdown: `##
+###
+####
+`,
+			want: []domain.Diagnostic{
+				{Line: 1, Rule: domain.RuleEmptyHeading},
+				{Line: 2, Rule: domain.RuleEmptyHeading},
+				{Line: 3, Rule: domain.RuleEmptyHeading},
+				{Line: 3, Rule: domain.RuleMissingSteps},
+				{Line: 3, Rule: domain.RuleMissingCheckpoints},
+			},
+			wantCases: 1,
+		},
+		{
+			name: "multiple incomplete cases use source order",
+			markdown: `## Setup
+### Environment
+#### Missing steps
+* [ ] Packages installed successfully
+#### Missing checkpoints
+1. Install required packages
+`,
+			want: []domain.Diagnostic{
+				{Line: 3, Rule: domain.RuleMissingSteps},
+				{Line: 5, Rule: domain.RuleMissingCheckpoints},
+			},
+			wantCases: 2,
+		},
+		{
+			name:     "document without hierarchy",
+			markdown: "# Inspection Sheet\n",
+			want: []domain.Diagnostic{
+				{Line: 1, Rule: domain.RuleHeadingHierarchy},
+			},
+		},
+		{
+			name: "incomplete hierarchy",
+			markdown: `## Setup
+### Environment
+`,
+			want: []domain.Diagnostic{
+				{Line: 2, Rule: domain.RuleHeadingHierarchy},
+			},
+		},
+		{
+			name: "major item without medium item",
+			markdown: `## Setup
+`,
+			want: []domain.Diagnostic{
+				{Line: 1, Rule: domain.RuleHeadingHierarchy},
+			},
+		},
+		{
+			name: "unsupported heading level",
+			markdown: `## Setup
+### Environment
+##### Detail
+`,
+			want: []domain.Diagnostic{
+				{Line: 2, Rule: domain.RuleHeadingHierarchy},
+				{Line: 3, Rule: domain.RuleUnsupportedHeading},
+			},
+		},
+		{
+			name: "duplicate and misplaced document titles",
+			markdown: `# Inspection Sheet
+# Duplicate
+## Setup
+### Environment
+#### Dependencies
+1. Install required packages
+* [ ] Packages installed successfully
+# Misplaced
+`,
+			want: []domain.Diagnostic{
+				{Line: 2, Rule: domain.RuleDocumentTitle},
+				{Line: 8, Rule: domain.RuleDocumentTitle},
+			},
+			wantCases: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const source = "scenario.md"
+
+			cases, diagnostics, err := ParseWithDiagnostics(source, strings.NewReader(tt.markdown))
+			if err != nil {
+				t.Fatalf("ParseWithDiagnostics() returned an unexpected error: %v", err)
+			}
+			if len(cases) != tt.wantCases {
+				t.Errorf("ParseWithDiagnostics() returned %d cases, want %d", len(cases), tt.wantCases)
+			}
+			if len(diagnostics) != len(tt.want) {
+				t.Fatalf("ParseWithDiagnostics() diagnostics = %+v, want %+v", diagnostics, tt.want)
+			}
+
+			for index, want := range tt.want {
+				got := diagnostics[index]
+				if got.Source != source || got.Line != want.Line || got.Rule != want.Rule {
+					t.Errorf("diagnostic %d = %+v, want source %q, line %d, rule %q", index, got, source, want.Line, want.Rule)
+				}
+				if got.Message == "" {
+					t.Errorf("diagnostic %d has an empty message", index)
+				}
+				if got.Suggestion == "" {
+					t.Errorf("diagnostic %d has an empty suggestion", index)
+				}
+			}
+
+			validated, err := Validate(source, strings.NewReader(tt.markdown))
+			if err != nil {
+				t.Fatalf("Validate() returned an unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(validated, diagnostics) {
+				t.Errorf("Validate() returned %+v, want %+v", validated, diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- define structured v1 validation diagnostics with source, line, rule, message, and correction guidance
- validate document titles, required heading hierarchy, empty headings, unsupported heading levels, ordered steps, and task-list checkpoints
- expose shared `Validate` and `ParseWithDiagnostics` APIs with diagnostics in stable source order
- add table-driven coverage for valid and invalid Markdown structures

## Architectural impact

Validation rules and diagnostic values live in the core layer. The application and interface layers remain unchanged, and the existing `Parse` API remains available as a compatibility wrapper. Conversion gating and the standalone CLI command remain scoped to #65.

## Verification

- `lefthook run pre-commit`
  - `gofmt`
  - `go test ./...`
  - `typos`
- `go test ./... -cover`
- `go vet ./...`
- `go build ./cmd/casemd`

Parser package coverage: 99.0%.

Closes #64