### PR TITLE
chore(devcontainer): add feature lockfile

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/lefthook-asdf:1": {
+      "version": "1.0.3",
+      "resolved": "ghcr.io/devcontainers-extra/features/lefthook-asdf@sha256:7eeba1f61b4eda2004fdced224c39a775c00e248790f35407353252b48f3cc43",
+      "integrity": "sha256:7eeba1f61b4eda2004fdced224c39a775c00e248790f35407353252b48f3cc43"
+    },
+    "ghcr.io/michidk/devcontainers-features/typos:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/michidk/devcontainers-features/typos@sha256:da745af5afb8b09ef2d312b51555e5e077cc5ee9fa3fa56d17b51eca34dcd952",
+      "integrity": "sha256:da745af5afb8b09ef2d312b51555e5e077cc5ee9fa3fa56d17b51eca34dcd952"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add the generated devcontainer feature lockfile
- pin `lefthook-asdf` and `typos` to resolved versions and immutable digests
- improve reproducibility without changing the declared devcontainer configuration

## Validation

- `devcontainer features resolve-dependencies --workspace-folder .`
- `devcontainer upgrade --workspace-folder . --dry-run`
- `jq empty .devcontainer/devcontainer-lock.json`
- `lefthook run pre-commit`
  - `go test ./...`
  - `typos`

The committed file exactly matches the current `devcontainer upgrade --dry-run` output.