### PR TITLE
feat(cli): add Markdown validation command

### DIFF
--- a/cmd/casemd/main.go
+++ b/cmd/casemd/main.go
@@ -19,8 +19,13 @@ func (p *coreParserAdapter) Parse(r io.Reader) ([]domain.Case, error) {
 	return parser.Parse(r)
 }
 
+func (p *coreParserAdapter) ParseWithDiagnostics(source string, r io.Reader) ([]domain.Case, []domain.Diagnostic, error) {
+	return parser.ParseWithDiagnostics(source, r)
+}
+
 func main() {
 	parserAdapter := &coreParserAdapter{}
+	validator := app.NewMarkdownValidator(parserAdapter)
 	csvConverter := app.NewMarkdownToCSV(parserAdapter)
 	spreadsheetConverter := app.NewMarkdownToSpreadsheet(parserAdapter)
 	var googleConverter cli.GoogleSpreadsheetCreator
@@ -51,7 +56,7 @@ func main() {
 		return
 	}
 
-	tool := cli.New(os.Stdout, os.Stderr, csvConverter, spreadsheetConverter, googleConverter)
+	tool := cli.New(os.Stdout, os.Stderr, validator, csvConverter, spreadsheetConverter, googleConverter)
 	application := app.New(tool)
 
 	if err := application.Run(os.Args[1:]); err != nil {

--- a/internal/app/converter.go
+++ b/internal/app/converter.go
@@ -15,11 +15,6 @@ import (
 	"github.com/9renpoto/casemd/internal/core/domain"
 )
 
-// CaseParser defines the behavior required to parse test cases from Markdown.
-type CaseParser interface {
-	Parse(r io.Reader) ([]domain.Case, error)
-}
-
 // Source represents a Markdown document and the metadata needed to build a sheet.
 type Source struct {
 	Name   string
@@ -65,18 +60,19 @@ func caseRow(aCase domain.Case) []string {
 
 // MarkdownToCSV orchestrates the conversion of Markdown test cases into CSV rows.
 type MarkdownToCSV struct {
-	parser CaseParser
+	parser MarkdownParser
 }
 
 // NewMarkdownToCSV wires the converter with the provided parser implementation.
-func NewMarkdownToCSV(parser CaseParser) *MarkdownToCSV {
+func NewMarkdownToCSV(parser MarkdownParser) *MarkdownToCSV {
 	return &MarkdownToCSV{parser: parser}
 }
 
 // Convert reads Markdown sources and writes a CSV document containing every parsed case.
 func (c *MarkdownToCSV) Convert(sources []Source, output io.Writer) error {
-	if len(sources) == 0 {
-		return fmt.Errorf("no sources provided")
+	parsedSources, err := requireValidSources(c.parser, sources)
+	if err != nil {
+		return err
 	}
 
 	writer := csv.NewWriter(output)
@@ -84,14 +80,8 @@ func (c *MarkdownToCSV) Convert(sources []Source, output io.Writer) error {
 		return fmt.Errorf("write csv header: %w", err)
 	}
 
-	for _, source := range sources {
-		cases, err := c.parser.Parse(source.Reader)
-		if err != nil {
-			writer.Flush()
-			return fmt.Errorf("parse %s: %w", source.Name, err)
-		}
-
-		for _, aCase := range cases {
+	for _, source := range parsedSources {
+		for _, aCase := range source.Cases {
 			if err := writer.Write(caseRow(aCase)); err != nil {
 				writer.Flush()
 				return fmt.Errorf("write csv row: %w", err)
@@ -109,37 +99,33 @@ func (c *MarkdownToCSV) Convert(sources []Source, output io.Writer) error {
 
 // MarkdownToSpreadsheet orchestrates the conversion of Markdown test cases into spreadsheet sheets.
 type MarkdownToSpreadsheet struct {
-	parser CaseParser
+	parser MarkdownParser
 }
 
 // NewMarkdownToSpreadsheet wires the converter with the provided parser implementation.
-func NewMarkdownToSpreadsheet(parser CaseParser) *MarkdownToSpreadsheet {
+func NewMarkdownToSpreadsheet(parser MarkdownParser) *MarkdownToSpreadsheet {
 	return &MarkdownToSpreadsheet{parser: parser}
 }
 
 // Convert reads Markdown data and writes a spreadsheet workbook with one sheet per Markdown file.
 func (c *MarkdownToSpreadsheet) Convert(sources []Source, output io.Writer) error {
-	if len(sources) == 0 {
-		return fmt.Errorf("no sources provided")
+	parsedSources, err := requireValidSources(c.parser, sources)
+	if err != nil {
+		return err
 	}
 
-	sheets := make([]workbookSheet, 0, len(sources))
+	sheets := make([]workbookSheet, 0, len(parsedSources))
 	nameUsage := make(map[string]int)
 	finalNames := make(map[string]struct{})
 
-	for index, source := range sources {
+	for index, source := range parsedSources {
 		sheetBase := deriveSheetName(source.Name, index)
 		sheetName := ensureUniqueSheetName(sheetBase, nameUsage, finalNames)
 
-		cases, err := c.parser.Parse(source.Reader)
-		if err != nil {
-			return fmt.Errorf("parse %s: %w", sheetName, err)
-		}
-
-		rows := make([][]string, 0, len(cases)+1)
+		rows := make([][]string, 0, len(source.Cases)+1)
 		rows = append(rows, append([]string(nil), spreadsheetHeaders...))
 
-		for _, aCase := range cases {
+		for _, aCase := range source.Cases {
 			rows = append(rows, caseRow(aCase))
 		}
 
@@ -151,12 +137,12 @@ func (c *MarkdownToSpreadsheet) Convert(sources []Source, output io.Writer) erro
 
 // MarkdownToGoogleSpreadsheet orchestrates the conversion of Markdown cases into Google Sheets.
 type MarkdownToGoogleSpreadsheet struct {
-	parser  CaseParser
+	parser  MarkdownParser
 	creator GoogleSpreadsheetCreator
 }
 
 // NewMarkdownToGoogleSpreadsheet wires the Google Sheets converter with the provided dependencies.
-func NewMarkdownToGoogleSpreadsheet(parser CaseParser, creator GoogleSpreadsheetCreator) *MarkdownToGoogleSpreadsheet {
+func NewMarkdownToGoogleSpreadsheet(parser MarkdownParser, creator GoogleSpreadsheetCreator) *MarkdownToGoogleSpreadsheet {
 	return &MarkdownToGoogleSpreadsheet{parser: parser, creator: creator}
 }
 
@@ -165,27 +151,23 @@ func (c *MarkdownToGoogleSpreadsheet) Create(ctx context.Context, title string, 
 	if title == "" {
 		return "", fmt.Errorf("spreadsheet title cannot be empty")
 	}
-	if len(sources) == 0 {
-		return "", fmt.Errorf("no sources provided")
+	parsedSources, err := requireValidSources(c.parser, sources)
+	if err != nil {
+		return "", err
 	}
 
-	sheets := make([]GoogleSpreadsheetSheet, 0, len(sources))
+	sheets := make([]GoogleSpreadsheetSheet, 0, len(parsedSources))
 	nameUsage := make(map[string]int)
 	finalNames := make(map[string]struct{})
 
-	for index, source := range sources {
+	for index, source := range parsedSources {
 		sheetBase := deriveSheetName(source.Name, index)
 		sheetName := ensureUniqueSheetName(sheetBase, nameUsage, finalNames)
 
-		cases, err := c.parser.Parse(source.Reader)
-		if err != nil {
-			return "", fmt.Errorf("parse %s: %w", sheetName, err)
-		}
-
-		rows := make([][]string, 0, len(cases)+1)
+		rows := make([][]string, 0, len(source.Cases)+1)
 		rows = append(rows, append([]string(nil), spreadsheetHeaders...))
 
-		for _, aCase := range cases {
+		for _, aCase := range source.Cases {
 			rows = append(rows, caseRow(aCase))
 		}
 

--- a/internal/app/converter_test.go
+++ b/internal/app/converter_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -16,12 +17,13 @@ import (
 )
 
 type mockCaseParser struct {
-	cases []domain.Case
-	err   error
+	cases       []domain.Case
+	diagnostics []domain.Diagnostic
+	err         error
 }
 
-func (m *mockCaseParser) Parse(r io.Reader) ([]domain.Case, error) {
-	return m.cases, m.err
+func (m *mockCaseParser) ParseWithDiagnostics(_ string, _ io.Reader) ([]domain.Case, []domain.Diagnostic, error) {
+	return m.cases, m.diagnostics, m.err
 }
 
 type mockGoogleCreator struct {
@@ -298,6 +300,55 @@ func TestMarkdownToGoogleSpreadsheet_CreateRequiresTitle(t *testing.T) {
 	_, err := converter.Create(context.Background(), "", sources)
 	if err == nil {
 		t.Fatalf("expected error for missing title")
+	}
+}
+
+func TestConvertersRejectDiagnosticsBeforeWriting(t *testing.T) {
+	diagnostic := domain.Diagnostic{
+		Source:  "invalid.md",
+		Line:    3,
+		Rule:    domain.RuleMissingSteps,
+		Message: "test case must contain at least one ordered step",
+	}
+	parser := &mockCaseParser{diagnostics: []domain.Diagnostic{diagnostic}}
+	sources := []Source{{Name: "invalid.md", Reader: strings.NewReader("")}}
+
+	t.Run("CSV", func(t *testing.T) {
+		var output bytes.Buffer
+		err := NewMarkdownToCSV(parser).Convert(sources, &output)
+		assertValidationError(t, err, diagnostic)
+		if output.Len() != 0 {
+			t.Fatalf("CSV output was written before validation completed: %q", output.String())
+		}
+	})
+
+	t.Run("spreadsheet", func(t *testing.T) {
+		var output bytes.Buffer
+		err := NewMarkdownToSpreadsheet(parser).Convert(sources, &output)
+		assertValidationError(t, err, diagnostic)
+		if output.Len() != 0 {
+			t.Fatalf("spreadsheet output was written before validation completed")
+		}
+	})
+
+	t.Run("Google Spreadsheet", func(t *testing.T) {
+		creator := &mockGoogleCreator{}
+		_, err := NewMarkdownToGoogleSpreadsheet(parser, creator).Create(context.Background(), "Export", sources)
+		assertValidationError(t, err, diagnostic)
+		if creator.spreadsheet.Title != "" {
+			t.Fatalf("Google Spreadsheet creator was invoked before validation completed")
+		}
+	})
+}
+
+func assertValidationError(t *testing.T, err error, want domain.Diagnostic) {
+	t.Helper()
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %v", err)
+	}
+	if !reflect.DeepEqual(validationErr.Diagnostics, []domain.Diagnostic{want}) {
+		t.Fatalf("diagnostics = %+v, want %+v", validationErr.Diagnostics, []domain.Diagnostic{want})
 	}
 }
 

--- a/internal/app/validator.go
+++ b/internal/app/validator.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/9renpoto/casemd/internal/core/domain"
+)
+
+// MarkdownParser parses cases and reports v1 Markdown diagnostics in one pass.
+type MarkdownParser interface {
+	ParseWithDiagnostics(source string, r io.Reader) ([]domain.Case, []domain.Diagnostic, error)
+}
+
+// ValidationError reports one or more v1 Markdown violations.
+type ValidationError struct {
+	Diagnostics []domain.Diagnostic
+}
+
+// Error summarizes the validation failure.
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("markdown validation failed with %d diagnostic(s)", len(e.Diagnostics))
+}
+
+// MarkdownValidator validates Markdown sources without producing artifacts.
+type MarkdownValidator struct {
+	parser MarkdownParser
+}
+
+// NewMarkdownValidator wires the validator with the shared Markdown parser.
+func NewMarkdownValidator(parser MarkdownParser) *MarkdownValidator {
+	return &MarkdownValidator{parser: parser}
+}
+
+// Validate checks every source and returns diagnostics in source and line order.
+func (v *MarkdownValidator) Validate(sources []Source) ([]domain.Diagnostic, error) {
+	_, diagnostics, err := parseSources(v.parser, sources)
+	return diagnostics, err
+}
+
+type parsedSource struct {
+	Name  string
+	Cases []domain.Case
+}
+
+func parseSources(parser MarkdownParser, sources []Source) ([]parsedSource, []domain.Diagnostic, error) {
+	if len(sources) == 0 {
+		return nil, nil, fmt.Errorf("no sources provided")
+	}
+
+	parsed := make([]parsedSource, 0, len(sources))
+	var diagnostics []domain.Diagnostic
+	for _, source := range sources {
+		cases, sourceDiagnostics, err := parser.ParseWithDiagnostics(source.Name, source.Reader)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parse %s: %w", source.Name, err)
+		}
+		parsed = append(parsed, parsedSource{Name: source.Name, Cases: cases})
+		diagnostics = append(diagnostics, sourceDiagnostics...)
+	}
+
+	return parsed, diagnostics, nil
+}
+
+func requireValidSources(parser MarkdownParser, sources []Source) ([]parsedSource, error) {
+	parsed, diagnostics, err := parseSources(parser, sources)
+	if err != nil {
+		return nil, err
+	}
+	if len(diagnostics) > 0 {
+		return nil, &ValidationError{Diagnostics: diagnostics}
+	}
+	return parsed, nil
+}

--- a/internal/interfaces/cli/tool.go
+++ b/internal/interfaces/cli/tool.go
@@ -12,11 +12,13 @@ import (
 	"strings"
 
 	"github.com/9renpoto/casemd/internal/app"
+	"github.com/9renpoto/casemd/internal/core/domain"
 )
 
 var (
 	errMissingInput                = errors.New("missing required flag: --input")
 	errMissingOutput               = errors.New("missing required flag: --csv-output, --spreadsheet-output, or --google-spreadsheet-title")
+	errMissingValidator            = errors.New("validation requested but validator is not configured")
 	errMissingCSVConverter         = errors.New("csv output requested but converter is not configured")
 	errMissingSpreadsheetConverter = errors.New("spreadsheet output requested but converter is not configured")
 	errMissingGoogleConverter      = errors.New("google spreadsheet requested but converter is not configured")
@@ -25,6 +27,11 @@ var (
 // Converter drives Markdown transformations from the CLI layer.
 type Converter interface {
 	Convert(sources []app.Source, output io.Writer) error
+}
+
+// Validator checks Markdown sources without producing artifacts.
+type Validator interface {
+	Validate(sources []app.Source) ([]domain.Diagnostic, error)
 }
 
 // GoogleSpreadsheetCreator drives Google Sheets creation from the CLI layer.
@@ -36,18 +43,57 @@ type GoogleSpreadsheetCreator interface {
 type Tool struct {
 	stdout               io.Writer
 	stderr               io.Writer
+	validator            Validator
 	csvConverter         Converter
 	spreadsheetConverter Converter
 	googleConverter      GoogleSpreadsheetCreator
 }
 
 // New creates a CLI tool with the provided output streams and conversion use case.
-func New(stdout, stderr io.Writer, csvConverter, spreadsheetConverter Converter, googleConverter GoogleSpreadsheetCreator) *Tool {
-	return &Tool{stdout: stdout, stderr: stderr, csvConverter: csvConverter, spreadsheetConverter: spreadsheetConverter, googleConverter: googleConverter}
+func New(stdout, stderr io.Writer, validator Validator, csvConverter, spreadsheetConverter Converter, googleConverter GoogleSpreadsheetCreator) *Tool {
+	return &Tool{stdout: stdout, stderr: stderr, validator: validator, csvConverter: csvConverter, spreadsheetConverter: spreadsheetConverter, googleConverter: googleConverter}
 }
 
 // Run parses CLI arguments, validates required options, and executes the conversion pipeline.
-func (t *Tool) Run(args []string) (err error) {
+func (t *Tool) Run(args []string) error {
+	if len(args) > 0 && args[0] == "validate" {
+		return t.runValidate(args[1:])
+	}
+	return t.runConvert(args)
+}
+
+func (t *Tool) runValidate(args []string) error {
+	fs := flag.NewFlagSet("casemd validate", flag.ContinueOnError)
+	fs.SetOutput(t.stderr)
+
+	var inputPaths multiValueFlag
+	fs.Var(&inputPaths, "input", "Path to the Markdown source file (repeat flag for multiple files)")
+	fs.Usage = func() {
+		fmt.Fprintf(t.stderr, "Validate Markdown inspection sheets without generating output artifacts.\n\n")
+		fmt.Fprintf(t.stderr, "Usage:\n  casemd validate --input <file> [--input <file> ...]\n\nFlags:\n")
+		fs.PrintDefaults()
+	}
+
+	help, err := parseFlagSet(fs, args)
+	if err != nil {
+		return err
+	}
+	if help {
+		return nil
+	}
+	if len(inputPaths) == 0 {
+		fs.Usage()
+		return errMissingInput
+	}
+
+	inputs, err := readInputFiles([]string(inputPaths))
+	if err != nil {
+		return err
+	}
+	return t.validateInputs(inputs)
+}
+
+func (t *Tool) runConvert(args []string) (err error) {
 	fs := flag.NewFlagSet("casemd", flag.ContinueOnError)
 	fs.SetOutput(t.stderr)
 
@@ -63,19 +109,16 @@ func (t *Tool) Run(args []string) (err error) {
 
 	fs.Usage = func() {
 		fmt.Fprintf(t.stderr, "casemd converts Markdown inspection sheets into CSV files, Excel workbooks, and Google Spreadsheets.\n\n")
-		fmt.Fprintf(t.stderr, "Usage:\n  casemd [flags]\n\nFlags:\n")
+		fmt.Fprintf(t.stderr, "Usage:\n  casemd [flags]\n  casemd validate --input <file> [--input <file> ...]\n\nFlags:\n")
 		fs.PrintDefaults()
 	}
 
-	if parseErr := fs.Parse(args); parseErr != nil {
-		if errors.Is(parseErr, flag.ErrHelp) {
-			return nil
-		}
+	help, parseErr := parseFlagSet(fs, args)
+	if parseErr != nil {
 		return parseErr
 	}
-
-	if fs.NArg() > 0 {
-		return fmt.Errorf("unexpected positional arguments: %v", fs.Args())
+	if help {
+		return nil
 	}
 
 	if len(inputPaths) == 0 {
@@ -91,6 +134,9 @@ func (t *Tool) Run(args []string) (err error) {
 	inputs, readErr := readInputFiles([]string(inputPaths))
 	if readErr != nil {
 		return readErr
+	}
+	if validationErr := t.validateInputs(inputs); validationErr != nil {
+		return validationErr
 	}
 
 	if csvOutputPath != "" {
@@ -154,6 +200,40 @@ func (t *Tool) Run(args []string) (err error) {
 	}
 
 	return nil
+}
+
+func parseFlagSet(fs *flag.FlagSet, args []string) (bool, error) {
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return true, nil
+		}
+		return false, err
+	}
+	if fs.NArg() > 0 {
+		return false, fmt.Errorf("unexpected positional arguments: %v", fs.Args())
+	}
+	return false, nil
+}
+
+func (t *Tool) validateInputs(inputs inputCollection) error {
+	if t.validator == nil {
+		return errMissingValidator
+	}
+	diagnostics, err := t.validator.Validate(inputs.asSources())
+	if err != nil {
+		return err
+	}
+	if len(diagnostics) == 0 {
+		return nil
+	}
+
+	for _, diagnostic := range diagnostics {
+		fmt.Fprintf(t.stderr, "%s:%d: %s: %s\n", diagnostic.Source, diagnostic.Line, diagnostic.Rule, diagnostic.Message)
+		if diagnostic.Suggestion != "" {
+			fmt.Fprintf(t.stderr, "  suggestion: %s\n", diagnostic.Suggestion)
+		}
+	}
+	return &app.ValidationError{Diagnostics: diagnostics}
 }
 
 type multiValueFlag []string

--- a/internal/interfaces/cli/tool_test.go
+++ b/internal/interfaces/cli/tool_test.go
@@ -4,13 +4,42 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/9renpoto/casemd/internal/app"
+	"github.com/9renpoto/casemd/internal/core/domain"
+	"github.com/9renpoto/casemd/internal/core/parser"
 )
+
+type mockValidator struct {
+	diagnostics []domain.Diagnostic
+	sources     []app.Source
+	err         error
+}
+
+func (m *mockValidator) Validate(sources []app.Source) ([]domain.Diagnostic, error) {
+	m.sources = sources
+	return m.diagnostics, m.err
+}
+
+type coreParserAdapter struct{}
+
+func (coreParserAdapter) ParseWithDiagnostics(source string, r io.Reader) ([]domain.Case, []domain.Diagnostic, error) {
+	return parser.ParseWithDiagnostics(source, r)
+}
+
+type mockConverter struct {
+	calls int
+}
+
+func (m *mockConverter) Convert(_ []app.Source, _ io.Writer) error {
+	m.calls++
+	return nil
+}
 
 type mockGoogleSpreadsheetCreator struct {
 	id      string
@@ -37,7 +66,7 @@ func TestToolRunCreatesGoogleSpreadsheet(t *testing.T) {
 	var stderr bytes.Buffer
 	creator := &mockGoogleSpreadsheetCreator{id: "sheet-id"}
 
-	tool := New(&stdout, &stderr, nil, nil, creator)
+	tool := New(&stdout, &stderr, &mockValidator{}, nil, nil, creator)
 	if err := tool.Run([]string{"--input", inputPath, "--google-spreadsheet-title", "Casemd Export"}); err != nil {
 		t.Fatalf("Run() returned an unexpected error: %v", err)
 	}
@@ -62,10 +91,127 @@ func TestToolRunRequiresGoogleConverter(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	tool := New(&stdout, &stderr, nil, nil, nil)
+	tool := New(&stdout, &stderr, &mockValidator{}, nil, nil, nil)
 
 	err := tool.Run([]string{"--input", inputPath, "--google-spreadsheet-title", "Casemd Export"})
 	if !errors.Is(err, errMissingGoogleConverter) {
 		t.Fatalf("expected errMissingGoogleConverter, got %v", err)
 	}
+}
+
+func TestToolRunValidateMultipleInputs(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := writeMarkdown(t, dir, "first.md", validMarkdown("First"))
+	secondPath := writeMarkdown(t, dir, "second.md", validMarkdown("Second"))
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	validator := app.NewMarkdownValidator(coreParserAdapter{})
+	tool := New(&stdout, &stderr, validator, nil, nil, nil)
+
+	if err := tool.Run([]string{"validate", "--input", firstPath, "--input", secondPath}); err != nil {
+		t.Fatalf("Run() returned an unexpected error: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("validate wrote to stdout: %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("validate wrote diagnostics for valid input: %q", stderr.String())
+	}
+}
+
+func TestToolRunValidateReportsActionableDiagnostics(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := writeMarkdown(t, dir, "invalid.md", "## Setup\n### Environment\n#### Incomplete\n")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	validator := app.NewMarkdownValidator(coreParserAdapter{})
+	tool := New(&stdout, &stderr, validator, nil, nil, nil)
+
+	err := tool.Run([]string{"validate", "--input", inputPath})
+	var validationErr *app.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %v", err)
+	}
+	if len(validationErr.Diagnostics) != 2 {
+		t.Fatalf("diagnostics = %+v, want missing steps and checkpoints", validationErr.Diagnostics)
+	}
+	for _, want := range []string{
+		inputPath + ":3: missing-steps:",
+		inputPath + ":3: missing-checkpoints:",
+		"suggestion:",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr %q does not contain %q", stderr.String(), want)
+		}
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("validate wrote to stdout: %q", stdout.String())
+	}
+}
+
+func TestToolRunRejectsInvalidInputBeforeCreatingAnyOutput(t *testing.T) {
+	dir := t.TempDir()
+	validPath := writeMarkdown(t, dir, "valid.md", validMarkdown("Valid"))
+	invalidPath := writeMarkdown(t, dir, "invalid.md", "## Setup\n### Environment\n#### Incomplete\n")
+	csvPath := filepath.Join(dir, "outputs", "cases.csv")
+	spreadsheetPath := filepath.Join(dir, "outputs", "cases.xlsx")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	validator := app.NewMarkdownValidator(coreParserAdapter{})
+	csvConverter := &mockConverter{}
+	spreadsheetConverter := &mockConverter{}
+	googleCreator := &mockGoogleSpreadsheetCreator{id: "should-not-exist"}
+	tool := New(&stdout, &stderr, validator, csvConverter, spreadsheetConverter, googleCreator)
+
+	err := tool.Run([]string{
+		"--input", validPath,
+		"--input", invalidPath,
+		"--csv-output", csvPath,
+		"--spreadsheet-output", spreadsheetPath,
+		"--google-spreadsheet-title", "Invalid Export",
+	})
+	var validationErr *app.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %v", err)
+	}
+	if csvConverter.calls != 0 || spreadsheetConverter.calls != 0 {
+		t.Fatalf("converters were called before validation completed: CSV=%d spreadsheet=%d", csvConverter.calls, spreadsheetConverter.calls)
+	}
+	if googleCreator.title != "" {
+		t.Fatalf("Google Spreadsheet creator was called before validation completed")
+	}
+	for _, path := range []string{csvPath, spreadsheetPath} {
+		if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("output %s exists or returned an unexpected error: %v", path, statErr)
+		}
+	}
+}
+
+func TestToolRunValidateHelp(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	tool := New(&stdout, &stderr, nil, nil, nil, nil)
+
+	if err := tool.Run([]string{"validate", "--help"}); err != nil {
+		t.Fatalf("Run() returned an unexpected error: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "casemd validate --input") {
+		t.Fatalf("help does not describe validate usage: %q", stderr.String())
+	}
+}
+
+func writeMarkdown(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write input file: %v", err)
+	}
+	return path
+}
+
+func validMarkdown(caseName string) string {
+	return "## Setup\n### Environment\n#### " + caseName + "\n1. Perform the action\n* [ ] Confirm the result\n"
 }


### PR DESCRIPTION
## Summary

- add `casemd validate --input <file>` with support for repeated inputs
- print deterministic source, line, rule, message, and suggestion diagnostics to stderr
- gate CSV, XLSX, and Google Sheets conversions through the shared v1 validation API
- validate every input before creating any local or remote output artifact
- update CLI help and add coverage for successful validation, actionable failures, and partial-output prevention

## Architectural impact

The application layer now owns a shared Markdown validator and structured validation error.
Converters consume `ParseWithDiagnostics` so validation and parsing use the same core API.
The CLI performs a preflight validation before opening files or calling Google Sheets, while each converter also enforces validation when invoked outside the CLI.

## Verification

- `lefthook run pre-commit`
  - `gofmt`
  - `go test ./...`
  - `typos`
- `go test ./... -cover`
- `go vet ./...`
- `go build ./cmd/casemd`
- manually verified `casemd validate --help` exits 0
- manually verified invalid Markdown emits diagnostics to stderr and exits non-zero

Closes #65